### PR TITLE
#169927801 Add Authentication to Create, Update and Delete Article APIs

### DIFF
--- a/server/helper/TokenHelperClass.js
+++ b/server/helper/TokenHelperClass.js
@@ -9,7 +9,6 @@ class TokenHelperClass {
  * @returns {Object} - Object containing details of decoded token
  */
   static verifyToken(token) {
-    if (!token) return { error: 'No token provided' };
     return jwt.verify(token, process.env.JWT_SECRET, (err, decoded) => {
       if (err) {
         return { error: err };

--- a/server/schema/index.js
+++ b/server/schema/index.js
@@ -54,14 +54,14 @@ const schema = buildSchema(`
   }
 
   input ArticleInput {
-    title: String!
-    body: String!
-    authorId: String!
+    title: String
+    token: String
+    body: String
   }
 
   input UpdateArticleInput {
     _id: ID
-    authorId: String
+    token: String!
     title: String
     body: String
     images: [String]
@@ -69,7 +69,7 @@ const schema = buildSchema(`
 
   input DeleteArticleInput {
     _id: ID!
-    authorId: String!
+    token: String
   }
 
   input UserInput {


### PR DESCRIPTION
#### What does this PR do?
- Have token authentication in Create, Update and Delete Article APIs

#### Description of Task to be completed?
- use verifyToken helper method to verify token
- add token field to createArticle, updateArticle and deleteArticle schemas
- remove authorId field from createArticle, updateArticle and deleteArticle schemas

#### How should this be manually tested?
- clone the repository
- cd into the folder and run npm run start-dev
- Go to localhost:3000/graphql and run the following mutations 
```
   createArticle (articleInput: {
        title: "Meh",
        body: "Meh again",
        token: ""
      }) {
    title
    body
  	author
    comments
    meta {
      favs
      votes
    }
  }
}
```
```
mutation {
  updateArticle(articleInput:{token:"insert token", _id: "5dd731ee4a0df2039caadbb2", title:"This new title that was updated is lit", body:"same with the new body"}) {
    author
    title
    body
    images
  }
}
```
```
mutation {
  deleteArticle(articleInput:{token:"insert token", _id: "5dd732874a0df2039caadbb3"}) {
    author
    title
    body
    images
  }
}
```

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
[#169927801](https://www.pivotaltracker.com/story/show/169927801)

#### Screenshots (if appropriate)
NA

#### Questions:
NA
